### PR TITLE
Use UTF-16BE encoding for bookmark titles

### DIFF
--- a/pdfcombine/__init__.py
+++ b/pdfcombine/__init__.py
@@ -83,7 +83,11 @@ def generate_postscript(
 
     if bookmarks:
         for bookmark, page in zip(bookmarks, pages):
-            out += [f"/Page {page:d} /Title <FEFF{bookmark.encode(encoding='utf-16-BE').hex().upper()}> /OUT pdfmark"]
+            out += [
+                f"/Page {page:d} "
+                f"/Title <FEFF{bookmark.encode(encoding='utf-16-BE').hex().upper()}> "
+                f"/OUT pdfmark"
+            ]
 
     if len(out) == 0:
         return ""

--- a/pdfcombine/__init__.py
+++ b/pdfcombine/__init__.py
@@ -83,7 +83,7 @@ def generate_postscript(
 
     if bookmarks:
         for bookmark, page in zip(bookmarks, pages):
-            out += [f"/Page {page:d} /Title ({bookmark:s}) /OUT pdfmark"]
+            out += [f"/Page {page:d} /Title <FEFF{bookmark.encode(encoding='utf-16-BE').hex().upper()}> /OUT pdfmark"]
 
     if len(out) == 0:
         return ""


### PR DESCRIPTION
In order to support special characters like in German words "Überschrift" or "Straße", I suggest to encode the bookmark titles with UTF-16BE.

I tested the change with a couple of files having such German umlauts and it works as expected.

I found the solution in this  [StackOveflow response](https://stackoverflow.com/a/72736506/9801061)

